### PR TITLE
Updated setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,4 +29,5 @@ setup(
 	install_requires=[
 		'setuptools',
 	],
+	packages=['mocktest', 'mocktest.matchers', 'mocktest.lib'],
 )


### PR DESCRIPTION
Hello,

 the setup.py provided in monktest didn't work on python 2.7 (but I didn't test either on other versions).
 I updated it to include the "packages" directive, and now "./setup.py install" works like a charm.

Best regards,
-Mathieu
