### PR TITLE
Fix install coveralls before running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ python:
   - "3.4"
 
 install:
+  - pip install --quiet coveralls
   - python setup.py install
 
 script:
   - nosetests --with-coverage --cover-package=mocktest
 
 after_success:
-  - pip install --quiet coveralls
   - coveralls


### PR DESCRIPTION
Fixes coverage part of #7 - now coveralls should work (as you can see in the [travis output](https://travis-ci.org/hayd/mocktest/jobs/61396752)).
